### PR TITLE
Add metadata, boilerplate, and CI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,6 @@
 *.v.html
 *.stamp
 *.native
-src/Makefile.coq
-src/Makefile.coq.conf
+Makefile.coq
+Makefile.coq.conf
 *.nia.cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,65 @@
+os: linux
+dist: bionic
+language: shell
+
+.opam: &OPAM
+  language: shell
+  services: docker
+  install: |
+    # Prepare the COQ container
+    docker pull ${COQ_IMAGE}
+    docker run -d -i --init --name=COQ -v ${TRAVIS_BUILD_DIR}:/home/coq/${PACKAGE} -w /home/coq/${PACKAGE} ${COQ_IMAGE}
+    docker exec COQ /bin/bash --login -c "
+      # This bash script is double-quoted to interpolate Travis CI env vars:
+      echo \"Build triggered by ${TRAVIS_EVENT_TYPE}\"
+      export PS4='+ \e[33;1m(\$0 @ line \$LINENO) \$\e[0m '
+      set -ex  # -e = exit on failure; -x = trace for debug
+      opam update -y
+      opam pin add ${PACKAGE} . -y -n -k path
+      opam install ${PACKAGE} -y -j ${NJOBS} --deps-only
+      opam config list
+      opam repo list
+      opam list
+      "
+  script:
+  - echo -e "${ANSI_YELLOW}Building ${PACKAGE}...${ANSI_RESET}" && echo -en 'travis_fold:start:script\\r'
+  - |
+    docker exec COQ /bin/bash --login -c "
+      export PS4='+ \e[33;1m(\$0 @ line \$LINENO) \$\e[0m '
+      set -ex
+      sudo chown -R coq:coq /home/coq/${PACKAGE}
+      opam install ${PACKAGE} -v -y -j ${NJOBS}
+      "
+  - docker stop COQ  # optional
+  - echo -en 'travis_fold:end:script\\r'
+
+.nix: &NIX
+  language: nix
+  install:
+  # for cachix we need travis to be a trusted nix user
+  - echo "trusted-users = $USER" | sudo tee -a /etc/nix/nix.conf
+  - sudo systemctl restart nix-daemon
+  script:
+  - nix-build --argstr coq-version-or-url "$COQ" --extra-substituters https://coq.cachix.org --trusted-public-keys "cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= coq.cachix.org-1:5QW/wwEnD+l2jvN6QRbRRsa4hBHG3QiQQ26cxu1F5tI="
+
+jobs:
+  include:
+
+  # Test supported versions of Coq via Nix
+  - env:
+    - COQ=https://github.com/coq/coq-on-cachix/tarball/master
+    <<: *NIX
+  - env:
+    - COQ=8.12
+    <<: *NIX
+  - env:
+    - COQ=8.11
+    <<: *NIX
+
+  # Test supported versions of Coq via OPAM
+  - env:
+    - COQ_IMAGE=coqorg/coq:dev
+    - PACKAGE=coq-coqtail.dev
+    - NJOBS=2
+    <<: *OPAM
+

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,16 @@
--include Makefile.coq
+all: Makefile.coq
+	@+$(MAKE) -f Makefile.coq all
+
+clean: Makefile.coq
+	@+$(MAKE) -f Makefile.coq cleanall
+	@rm -f Makefile.coq Makefile.coq.conf
 
 Makefile.coq: _CoqProject
-	coq_makefile -f _CoqProject -o Makefile.coq
+	$(COQBIN)coq_makefile -f _CoqProject -o Makefile.coq
 
-superclean: cleanall
-	rm -f .Makefile.d Makefile.coq Makefile.coq.conf
+force _CoqProject Makefile: ;
+
+%: Makefile.coq force
+	@+$(MAKE) -f Makefile.coq $@
+
+.PHONY: all clean force

--- a/README.md
+++ b/README.md
@@ -1,44 +1,60 @@
 # Coqtail
 
-[Coqtail](https://coqtail.github.io/index.html) is a library of
-mathematical theorems and tools proved inside the Coq proof assistant.
-Results range mostly from arithmetic to real and complex analysis.
+[![Travis][travis-shield]][travis-link]
+[![Contributing][contributing-shield]][contributing-link]
+[![Code of Conduct][conduct-shield]][conduct-link]
+[![Zulip][zulip-shield]][zulip-link]
+
+[travis-shield]: https://travis-ci.com/coq-community/coqtail-math.svg?branch=master
+[travis-link]: https://travis-ci.com/coq-community/coqtail-math/builds
+
+[contributing-shield]: https://img.shields.io/badge/contributions-welcome-%23f7931e.svg
+[contributing-link]: https://github.com/coq-community/manifesto/blob/master/CONTRIBUTING.md
+
+[conduct-shield]: https://img.shields.io/badge/%E2%9D%A4-code%20of%20conduct-%23f15a24.svg
+[conduct-link]: https://github.com/coq-community/manifesto/blob/master/CODE_OF_CONDUCT.md
+
+[zulip-shield]: https://img.shields.io/badge/chat-on%20zulip-%23c1272d.svg
+[zulip-link]: https://coq.zulipchat.com/#narrow/stream/237663-coq-community-devs.20.26.20users
+
+
+
+Coqtail is a library of mathematical theorems and tools proved inside
+the Coq proof assistant. Results range mostly from arithmetic to real
+and complex analysis.
+
+## Meta
+
+- Author(s):
+  - Guillaume Allais
+  - Jean-Marie Madiot
+  - Pierre-Marie Pédrot
+- Coq-community maintainer(s):
+  - Jean-Marie Madiot ([**@jmadiot**](https://github.com/jmadiot))
+- License: [GNU Lesser General Public License v3.0 only](LICENSE)
+- Compatible Coq versions: 8.11 or later
+- Additional dependencies: none
+- Coq namespace: `Coqtail`
+- Related publication(s): none
+
+## Building instructions
+
+``` shell
+git clone https://github.com/coq-community/coqtail-math
+cd coqtail-math
+make   # or make -j <number-of-cores-on-your-machine>
+```
+
+## Coqtail and Vim
 
 Note that this project is distinct from [this other project named
-Coqtail](https://github.com/whonore/Coqtail), which helps using Coq in
-Vim.
-
-## Requirements
-
-`master` is developed with Coq 8.12.0, which is its only requirement,
-but the following git tags point to snapshots for different versions
-of Coq, which should cover most versions from 8.5 to 8.12.0.
-
-- tag `v8.6.1` for Coq 8.5pl3 and Coq 8.6.1
-- tag `v8.7.2` for Coq 8.7.2
-- tag `v8.8.2` for Coq 8.8.2
-- tag `v8.9.1` for Coq 8.9.1
-- tag `v8.10.2` for Coq 8.10.2
-- tag `v8.11.0` for Coq 8.11.0
-- tag `v8.11.2` for Coq 8.11.2
-
-Use e.g. `git checkout v8.10.2` if you want to use Coq 8.10.2. Note
-that those tags are for backward compatibility only, there is no
-intention of maintaining them as branches: use master instead for
-development.
-
-## Compiling
-
-Running `make` should suffice. It uses a `_CoqProject` file, which
-should also allow you to use coqide and proofgeneral with no further
-configuration.
+Coqtail](https://github.com/whonore/Coqtail), which helps using Coq in Vim.
 
 ## Developer's todo list
 
 Big things:
 
-- prove linear and non-linear theory of ℂ is decidable (using Groebner
-  basis)
+- prove linear and non-linear theory of ℂ is decidable (using Groebner basis)
 
 Lemmas to prove:
 
@@ -47,9 +63,8 @@ Lemmas to prove:
 
 Maintenance:
 
-- Use -Q instead of -R and fix the resulting loadpath problems
-- Opam package for `make install`
+- Use `-Q` instead of `-R` and fix the resulting loadpath problems
 - Check for commented lemmas (and admits)
-- Remove useless "Require"s
-- Check for admits (run "./todos.sh").
-- Check for commented results (run "./todos.sh comments")
+- Remove useless `Require`s
+- Check for admits (run `./todos.sh`).
+- Check for commented results (run `./todos.sh comments`)

--- a/README.md
+++ b/README.md
@@ -27,8 +27,11 @@ and complex analysis.
 
 - Author(s):
   - Guillaume Allais
+  - Sylvain Dailler
+  - Hugo Férée
   - Jean-Marie Madiot
   - Pierre-Marie Pédrot
+  - Amaury Pouly
 - Coq-community maintainer(s):
   - Jean-Marie Madiot ([**@jmadiot**](https://github.com/jmadiot))
 - License: [GNU Lesser General Public License v3.0 only](LICENSE)

--- a/_CoqProject
+++ b/_CoqProject
@@ -1,12 +1,4 @@
 -R . Coqtail
--I Arith
--I Complex
--I Fresh
--I Hierarchy
--I Monad
--I mytheories
--I Reals
--I Tactics
 
 Arith/Hurwitz_def.v
 Arith/Hurwitz_prop.v

--- a/coq-coqtail.opam
+++ b/coq-coqtail.opam
@@ -27,6 +27,9 @@ tags: [
 ]
 authors: [
   "Guillaume Allais"
+  "Sylvain Dailler"
+  "Hugo Férée"
   "Jean-Marie Madiot"
   "Pierre-Marie Pédrot"
+  "Amaury Pouly"
 ]

--- a/coq-coqtail.opam
+++ b/coq-coqtail.opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+maintainer: "palmskog@gmail.com"
+version: "dev"
+
+homepage: "https://github.com/coq-community/coqtail-math"
+dev-repo: "git+https://github.com/coq-community/coqtail-math.git"
+bug-reports: "https://github.com/coq-community/coqtail-math/issues"
+license: "LGPL-3.0-only"
+
+synopsis: "Library of mathematical theorems and tools proved inside the Coq"
+description: """
+Coqtail is a library of mathematical theorems and tools proved inside
+the Coq proof assistant. Results range mostly from arithmetic to real
+and complex analysis."""
+
+build: [make "-j%{jobs}%" ]
+install: [make "install"]
+depends: [
+  "coq" {(>= "8.11" & < "8.13~") | (= "dev")}
+]
+
+tags: [
+  "category:Mathematics/Real Calculus and Topology"
+  "keyword:real analysis"
+  "keyword:complex analysis"
+  "logpath:Coqtail"
+]
+authors: [
+  "Guillaume Allais"
+  "Jean-Marie Madiot"
+  "Pierre-Marie Pédrot"
+]

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,25 @@
+{ pkgs ? (import <nixpkgs> {}), coq-version-or-url, shell ? false }:
+
+let
+  coq-version-parts = builtins.match "([0-9]+).([0-9]+)" coq-version-or-url;
+  coqPackages =
+    if coq-version-parts == null then
+      pkgs.mkCoqPackages (import (fetchTarball coq-version-or-url) {})
+    else
+      pkgs."coqPackages_${builtins.concatStringsSep "_" coq-version-parts}";
+in
+
+with coqPackages;
+
+pkgs.stdenv.mkDerivation {
+
+  name = "coqtail-math";
+
+  propagatedBuildInputs = [
+    coq
+  ];
+
+  src = if shell then null else ./.;
+
+  installFlags = "COQMF_COQLIB=$(out)/lib/coq/${coq.coq-version}/";
+}

--- a/default.nix
+++ b/default.nix
@@ -13,7 +13,9 @@ with coqPackages;
 
 pkgs.stdenv.mkDerivation {
 
-  name = "coqtail-math";
+  name = "coqtail";
+
+  buildInputs = with coq.ocamlPackages; [ ocaml findlib ];
 
   propagatedBuildInputs = [
     coq

--- a/dune
+++ b/dune
@@ -1,0 +1,6 @@
+(coq.theory
+ (name Coqtail)
+ (package coq-coqtail)
+ (synopsis "Library of mathematical theorems and tools proved inside the Coq"))
+
+(include_subdirs qualified)

--- a/dune-project
+++ b/dune-project
@@ -1,0 +1,3 @@
+(lang dune 2.5)
+(using coq 0.2)
+(name coqtail-math)

--- a/meta.yml
+++ b/meta.yml
@@ -1,0 +1,87 @@
+---
+fullname: Coqtail
+shortname: coqtail-math
+opam_name: coq-coqtail
+organization: coq-community
+community: true
+travis: true
+
+synopsis: Library of mathematical theorems and tools proved inside the Coq
+
+description: |-
+  Coqtail is a library of mathematical theorems and tools proved inside
+  the Coq proof assistant. Results range mostly from arithmetic to real
+  and complex analysis.
+
+authors:
+- name: Guillaume Allais
+- name: Jean-Marie Madiot
+- name: Pierre-Marie Pédrot
+
+maintainers:
+- name: Jean-Marie Madiot
+  nickname: jmadiot
+
+opam-file-maintainer: palmskog@gmail.com
+
+opam-file-version: dev
+
+license:
+  fullname: GNU Lesser General Public License v3.0 only
+  identifier: LGPL-3.0-only
+
+supported_coq_versions:
+  text: 8.11 or later
+  opam: '{(>= "8.11" & < "8.13~") | (= "dev")}'
+
+tested_coq_nix_versions:
+- version_or_url: https://github.com/coq/coq-on-cachix/tarball/master
+- version_or_url: '8.12'
+- version_or_url: '8.11'
+
+tested_coq_opam_versions:
+- version: dev
+
+namespace: Coqtail
+
+build: |-
+ ## Building instructions
+
+ ``` shell
+ git clone https://github.com/coq-community/coqtail-math
+ cd coqtail-math
+ make   # or make -j <number-of-cores-on-your-machine>
+ ```
+
+keywords:
+- name: real analysis
+- name: complex analysis
+
+categories:
+- name: Mathematics/Real Calculus and Topology
+
+documentation: |-
+  ## Coqtail and Vim
+
+  Note that this project is distinct from [this other project named
+  Coqtail](https://github.com/whonore/Coqtail), which helps using Coq in Vim.
+
+  ## Developer's todo list
+
+  Big things:
+
+  - prove linear and non-linear theory of ℂ is decidable (using Groebner basis)
+
+  Lemmas to prove:
+
+  - Mertens' Theorem for Complex numbers
+  - (expand this list to your wish)
+
+  Maintenance:
+
+  - Use `-Q` instead of `-R` and fix the resulting loadpath problems
+  - Check for commented lemmas (and admits)
+  - Remove useless `Require`s
+  - Check for admits (run `./todos.sh`).
+  - Check for commented results (run `./todos.sh comments`)
+---

--- a/meta.yml
+++ b/meta.yml
@@ -15,8 +15,11 @@ description: |-
 
 authors:
 - name: Guillaume Allais
+- name: Sylvain Dailler
+- name: Hugo Férée
 - name: Jean-Marie Madiot
 - name: Pierre-Marie Pédrot
+- name: Amaury Pouly
 
 maintainers:
 - name: Jean-Marie Madiot


### PR DESCRIPTION
This adds the usual coq-community `meta.yml` from which boilerplate is generated. I also used a more standard delegating Makefile and added Dune support.