### PR TITLE
update ci boilerplate for 8.14

### DIFF
--- a/.github/workflows/docker-action.yml
+++ b/.github/workflows/docker-action.yml
@@ -18,6 +18,7 @@ jobs:
       matrix:
         image:
           - 'coqorg/coq:dev'
+          - 'coqorg/coq:8.14'
           - 'coqorg/coq:8.13'
           - 'coqorg/coq:8.12'
           - 'coqorg/coq:8.11'

--- a/coq-coqtail.opam
+++ b/coq-coqtail.opam
@@ -16,7 +16,7 @@ Coqtail is a library of mathematical theorems and tools proved inside
 the Coq proof assistant. Results range mostly from arithmetic to real
 and complex analysis."""
 
-build: [make "-j%{jobs}%" ]
+build: [make "-j%{jobs}%"]
 install: [make "install"]
 depends: [
   "coq" {(>= "8.11" & < "8.15~") | (= "dev")}

--- a/dune
+++ b/dune
@@ -2,7 +2,7 @@
  (name Coqtail)
  (package coq-coqtail)
  (synopsis "Library of mathematical theorems and tools proved inside the Coq")
- (flags
+ (flags :standard
    -w -deprecated-hint-without-locality
    -w -deprecated-hint-rewrite-without-locality
    -w -deprecated-instance-without-locality))

--- a/meta.yml
+++ b/meta.yml
@@ -42,6 +42,7 @@ tested_coq_nix_versions:
 
 tested_coq_opam_versions:
 - version: dev
+- version: '8.14'
 - version: '8.13'
 - version: '8.12'
 - version: '8.11'
@@ -49,13 +50,13 @@ tested_coq_opam_versions:
 namespace: Coqtail
 
 build: |-
- ## Building instructions
+  ## Building instructions
 
- ``` shell
- git clone https://github.com/coq-community/coqtail-math
- cd coqtail-math
- make   # or make -j <number-of-cores-on-your-machine>
- ```
+  ``` shell
+  git clone https://github.com/coq-community/coqtail-math
+  cd coqtail-math
+  make   # or make -j <number-of-cores-on-your-machine>
+  ```
 
 keywords:
 - name: real analysis


### PR DESCRIPTION
After this is merged, can we maybe get a release/tag on `master`? (For packaging a version compatible with 8.14.)