### PR TITLE
Compatibility and CI for 8.17 and later

### DIFF
--- a/.github/workflows/docker-action.yml
+++ b/.github/workflows/docker-action.yml
@@ -18,17 +18,21 @@ jobs:
       matrix:
         image:
           - 'coqorg/coq:dev'
+          - 'coqorg/coq:8.17'
+          - 'coqorg/coq:8.16'
+          - 'coqorg/coq:8.15'
           - 'coqorg/coq:8.14'
           - 'coqorg/coq:8.13'
           - 'coqorg/coq:8.12'
           - 'coqorg/coq:8.11'
       fail-fast: false
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: coq-community/docker-coq-action@v1
         with:
           opam_file: 'coq-coqtail.opam'
           custom_image: ${{ matrix.image }}
+
 
 # See also:
 # https://github.com/coq-community/docker-coq-action#readme

--- a/Arith/MillerRabin.v
+++ b/Arith/MillerRabin.v
@@ -562,7 +562,8 @@ Lemma first_miller_rabin_2_pseudo_prime :
   miller_rabin [2; 3] 2047 = false /\
   primeb              2047 = false.
 Proof.
-  now native_compute.
+  (*now native_compute.*)
+  now vm_compute.
 Qed.
 
 (** Below 1373653, it is enough to check a=3, but we check for <= 10000 *)
@@ -570,7 +571,8 @@ Qed.
 Lemma miller_rabin_2_3 n : n <= 10000 -> miller_rabin [2; 3] n = primeb n.
 Proof.
   apply MR_range_spec_2.
-  Time native_compute. (* 1.6 secs *)
+  (*Time native_compute.*) (* 1.6 secs *)
+  Time vm_compute.
   reflexivity.
 Time Qed. (* 1.6 secs *)
 
@@ -579,5 +581,6 @@ Lemma first_miller_rabin_2_3_pseudo_prime :
   miller_rabin [2; 3; 5] 1373653 = false /\
   primeb                 1373653 = false.
 Proof.
-  now native_compute.
+  (*now native_compute.*)
+  now vm_compute.
 Qed.

--- a/Arith/Ndiv.v
+++ b/Arith/Ndiv.v
@@ -1232,7 +1232,9 @@ rewrite minus_plus.
 rewrite H5 in H4.
 rewrite plus_comm.
 rewrite H4.
-auto. auto. auto with arith.
+lia.
+auto with arith.
+auto with arith.
 Qed.
 
 (** Lowest strict divisor is lowest divisor *)

--- a/README.md
+++ b/README.md
@@ -44,13 +44,25 @@ and complex analysis.
 - Coq namespace: `Coqtail`
 - Related publication(s): none
 
-## Building instructions
+## Building and installation instructions
+
+The easiest way to install the latest released version of Coqtail
+is via [OPAM](https://opam.ocaml.org/doc/Install.html):
+
+```shell
+opam repo add coq-released https://coq.inria.fr/opam/released
+opam install coq-coqtail
+```
+
+To instead build and install manually, do:
 
 ``` shell
-git clone https://github.com/coq-community/coqtail-math
+git clone https://github.com/coq-community/coqtail-math.git
 cd coqtail-math
-make   # or make -j <number-of-cores-on-your-machine>
+make   # or make -j <number-of-cores-on-your-machine> 
+make install
 ```
+
 
 ## Coqtail and Vim
 

--- a/coq-coqtail.opam
+++ b/coq-coqtail.opam
@@ -19,7 +19,7 @@ and complex analysis."""
 build: [make "-j%{jobs}%"]
 install: [make "install"]
 depends: [
-  "coq" {(>= "8.11" & < "8.15~") | (= "dev")}
+  "coq" {(>= "8.11" & < "8.18~") | (= "dev")}
 ]
 
 tags: [

--- a/meta.yml
+++ b/meta.yml
@@ -35,28 +35,22 @@ license:
 
 supported_coq_versions:
   text: 8.11 or later
-  opam: '{(>= "8.11" & < "8.15~") | (= "dev")}'
+  opam: '{(>= "8.11" & < "8.18~") | (= "dev")}'
 
 tested_coq_nix_versions:
 - coq_version: 'master'
 
 tested_coq_opam_versions:
 - version: dev
+- version: '8.17'
+- version: '8.16'
+- version: '8.15'
 - version: '8.14'
 - version: '8.13'
 - version: '8.12'
 - version: '8.11'
 
 namespace: Coqtail
-
-build: |-
-  ## Building instructions
-
-  ``` shell
-  git clone https://github.com/coq-community/coqtail-math
-  cd coqtail-math
-  make   # or make -j <number-of-cores-on-your-machine>
-  ```
 
 keywords:
 - name: real analysis


### PR DESCRIPTION
I switch uses of `native_compute` to `vm_compute` for compatibility reasons.

After this is merged, maybe a new tag/release would be nice?